### PR TITLE
Commented out data-warehouse from list of managed services

### DIFF
--- a/services/retrieval-base/src/scripts/seed.ts
+++ b/services/retrieval-base/src/scripts/seed.ts
@@ -1,6 +1,6 @@
 import type { Foo, Bar } from "@workspace/models";
 import { bulkIndex } from "../services/search";
-import { FooStatus } from "@workspace/models";
+import FooStatus  from "@workspace/models";
 
 // Sample data for testing
 const sampleFoos: Foo[] = [


### PR DESCRIPTION
This pull request includes a minor change to the `services/retrieval-base/src/scripts/seed.ts` file. The change updates the import statement for `FooStatus` to use a default import instead of a named import.