### PR TITLE
use min instead of deprecated t

### DIFF
--- a/apps/dw-frontend/main.py
+++ b/apps/dw-frontend/main.py
@@ -302,7 +302,7 @@ elif page == "Connector analytics":
         st.dataframe(breakdown, hide_index=True)
         # --- Items per minute chart ---
         if "Processed On" in df.columns:
-            df["Processed On (minute)"] = pd.to_datetime(df["Processed On"], errors="coerce").dt.floor("T")
+            df["Processed On (minute)"] = pd.to_datetime(df["Processed On"], errors="coerce").dt.floor("min")
             per_min = df.groupby(["Processed On (minute)", "Source"]).size().reset_index(name="Count")
             per_min_pivot = per_min.pivot(index="Processed On (minute)", columns="Source", values="Count").fillna(0)
             per_min_pivot = per_min_pivot.sort_index()


### PR DESCRIPTION
```
FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.
```